### PR TITLE
fix: PR description on type others

### DIFF
--- a/src/utils/commons.ts
+++ b/src/utils/commons.ts
@@ -19,8 +19,7 @@ const getPrType = (prTitle: string): PR_TYPES => {
   return type ? type[1] : PR_TYPES.others;
 };
 
-const getPrDescription = (prRawDescription) =>
-  prRawDescription.split(":").slice(-1)[0].trim();
+const getPrDescription = (prRawDescription, type) => type === PR_TYPES.others ? prRawDescription : prRawDescription.split(":").slice(-1)[0].trim();
 
 const splitCommitsByType = (rawCommits: Commits): SplitCommits => {
   const commits = Object.values(PR_TYPES).reduce((acc, cur) => {

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -22,11 +22,14 @@ const getCommits = async (
     commit.message.split("\n\n")
   );
 
-  const commits = messages.map(([prTitle, prRawDescription]) => ({
-    type: getPrType(prTitle),
-    number: getPrNumber(prTitle),
-    description: getPrDescription(prRawDescription),
-  }));
+  const commits = messages.map(([prTitle, prRawDescription]) => {
+    const type =  getPrType(prTitle);
+    return {
+      type,
+      number: getPrNumber(prTitle),
+      description: getPrDescription(prRawDescription, type),
+    };
+  });
 
   return commits;
 };


### PR DESCRIPTION
## Background
`getPrDescription` fails on processing messages identified as `PR_TYPES.others`

## Changes done
* update `getPrDescription` to expect a `PR_TYPES` 
