### PR TITLE
fix: commit comparation 

### DIFF
--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -1,15 +1,18 @@
 import type { Commits, OctokitClient, Repository } from "../types"
 import { getPrDescription, getPrNumber, getPrType } from "./commons"
 
-
+/**
+ * @todo Accept a list of branches to compare via config
+ */
 const getCommits = async (
   octokitClient: OctokitClient,
-  repo: Repository
+  repo: Repository,
+  compareBranches = { base: "main", head: "development" }
 ): Promise<Commits> => {
   const commitsRequest =
     await octokitClient.rest.repos.compareCommitsWithBasehead({
       ...repo,
-      basehead: "staging...development",
+      basehead: `${compareBranches.base}...${compareBranches.head}`,
     });
 
   const { commits: rawCommits } = commitsRequest.data;


### PR DESCRIPTION
## Background
We were getting the full list of commit in our new project, the main reason is that we're not creating release PRs against staging but main;

New projects might not follow the adopted workflow; so we will need to consume the branch's names via action configuration.
